### PR TITLE
Update generate-token.php

### DIFF
--- a/examples/generate-token.php
+++ b/examples/generate-token.php
@@ -37,7 +37,9 @@ session_start();
 if (isset($_GET['reset'])) {
     $_SESSION = [];
 } elseif (isset($_SESSION['accessToken'])) {
-    $accessToken = new AccessToken($_SESSION['accessToken']);
+    $accessToken = new AccessToken([
+        'access_token' => $_SESSION['accessToken']
+    ]);
 }
 
 /** @noinspection PhpStatementHasEmptyBodyInspection */


### PR DESCRIPTION
The constructor of `League\OAuth2\Client\Token\AccessToken` requires an array and not a string